### PR TITLE
Feature/revenuecat attribute cleanup

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -187,11 +187,36 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
     Purchases.configure(withAPIKey: "YOUR_REVENUE_CAT_API_KEY")
 
-    if let applicationUsername = InsertAffiliateSwift.returnInsertAffiliateIdentifier() {
-      Purchases.shared.attribution.setAttributes(["insert_affiliate": applicationUsername])
-      Purchases.shared.syncAttributesAndOfferingsIfNeeded { offerings, error in
-        // Offerings are now synced with the latest attributes
+    // Set up callback to sync affiliate attributes to RevenueCat whenever they change
+    InsertAffiliateSwift.setInsertAffiliateIdentifierChangeCallback { identifier, offerCode in
+      guard let identifier = identifier else { return }
+
+      // Ensure subscriber exists before setting attributes
+      Purchases.shared.getCustomerInfo { customerInfo, error in
+        // Set attributes for tracking and targeting
+        var attributes: [String: String] = [
+          "insert_affiliate": identifier,
+          "insert_timedout": ""  // Clear timeout flag
+        ]
+        if let offerCode = offerCode {
+          attributes["affiliateOfferCode"] = offerCode  // For RevenueCat targeting
+        }
+
+        Purchases.shared.attribution.setAttributes(attributes)
+
+        // Sync to enable targeting based on affiliateOfferCode
+        Purchases.shared.syncAttributesAndOfferingsIfNeeded { offerings, error in
+          print("Offerings synced, current: \(offerings?.current?.identifier ?? "none")")
+        }
       }
+    }
+
+    // Initialize Insert Affiliate SDK
+    InsertAffiliateSwift.initialize(companyCode: "YOUR_COMPANY_CODE", verboseLogging: true)
+
+    // Sync existing affiliate on app launch
+    if let existingAffiliate = InsertAffiliateSwift.returnInsertAffiliateIdentifier() {
+      Purchases.shared.attribution.setAttributes(["insert_affiliate": existingAffiliate])
     }
 
     return true
@@ -200,6 +225,14 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 ```
 
 Replace `YOUR_REVENUE_CAT_API_KEY` with your **RevenueCat API Key** from [here](https://www.revenuecat.com/docs/welcome/authentication).
+
+**RevenueCat Targeting (Optional)**
+
+To show different offerings based on affiliate offer codes:
+
+1. In RevenueCat Dashboard, go to **Project Settings → Targeting**
+2. Create a rule: "When `affiliateOfferCode` equals `yourOfferCode`, show offering `your_special_offering`"
+3. The SDK automatically sets `affiliateOfferCode` when an affiliate has one configured
 
 **Step 2: Webhook Setup**
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -138,7 +138,8 @@ InsertAffiliateSwift.initialize(
     verboseLogging: true,                      // Enable verbose logging
     insertLinksEnabled: true,                  // Enable Insert Links
     insertLinksClipboardEnabled: true,         // Enable clipboard access (triggers permission prompt)
-    affiliateAttributionActiveTime: 604800     // Optional: 7 days attribution timeout (default: no timeout)
+    affiliateAttributionActiveTime: 604800,    // Optional: 7 days attribution timeout (default: no timeout)
+    preventAffiliateTransfer: true             // Optional: Protect original affiliate from being overwritten
 )
 ```
 
@@ -152,6 +153,7 @@ InsertAffiliateSwift.initialize(
   - **User experience**: iOS will show a one-time permission prompt: "[Your App] would like to paste from [App Name]"
   - **Recommendation**: Strongly recommended for maximum attribution accuracy, though users will see the clipboard permission prompt
 - `affiliateAttributionActiveTime`: How long affiliate attribution lasts in seconds (0 = never expires)
+- `preventAffiliateTransfer`: When `true`, protects the original affiliate from being overwritten by subsequent affiliate links. [Learn more](https://docs.insertaffiliate.com/prevent-affiliate-transfer)
 
 </details>
 
@@ -470,10 +472,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       insertLinksClipboardEnabled: false // Set to true if attribution accuracy is most important (triggers clipboard permission prompt)
     )
 
-    // Set up callback for affiliate identifier changes
-    InsertAffiliateSwift.setInsertAffiliateIdentifierChangeCallback { identifier in
+    // Set up callback for affiliate identifier changes (receives identifier and optional offer code)
+    InsertAffiliateSwift.setInsertAffiliateIdentifierChangeCallback { identifier, offerCode in
       if let identifier = identifier {
         print("Affiliate identifier: \(identifier)")
+        if let offerCode = offerCode {
+          print("Offer code: \(offerCode)")
+        }
 
         // If using RevenueCat, update attributes here
         // Purchases.shared.attribution.setAttributes(["insert_affiliate": identifier])
@@ -776,6 +781,47 @@ if let storedDate = InsertAffiliateSwift.getAffiliateStoredDate() {
     print("Affiliate stored on: \(storedDate)")
 }
 ```
+
+**Get Expiry Timestamp:**
+
+```swift
+if let expiryTimestamp = InsertAffiliateSwift.getAffiliateExpiryTimestamp() {
+    print("Attribution expires at: \(expiryTimestamp) ms since epoch")
+    // Convert to Date if needed
+    let expiryDate = Date(timeIntervalSince1970: Double(expiryTimestamp) / 1000)
+    print("Expiry date: \(expiryDate)")
+}
+```
+
+</details>
+
+<details>
+<summary><h3>Prevent Affiliate Transfer</h3></summary>
+
+Protect the original affiliate's attribution from being overwritten when users click different affiliate links.
+
+**Enable During Initialization:**
+
+```swift
+InsertAffiliateSwift.initialize(
+    companyCode: "YOUR_COMPANY_CODE",
+    preventAffiliateTransfer: true
+)
+```
+
+**How It Works:**
+1. User clicks Affiliate A's link → Attribution stored
+2. `preventAffiliateTransfer: true` is set
+3. User clicks Affiliate B's link → SDK detects existing attribution
+4. Transfer blocked → Affiliate B's link is silently ignored
+5. User purchases → Affiliate A receives commission
+
+**Use Cases:**
+- Prevent "affiliate stealing" scenarios
+- Ensure the first affiliate to acquire a user always receives credit
+- Protect long-term affiliate relationships
+
+📖 **[Learn more about Prevent Affiliate Transfer →](https://docs.insertaffiliate.com/prevent-affiliate-transfer)**
 
 </details>
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -188,11 +188,18 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     Purchases.configure(withAPIKey: "YOUR_REVENUE_CAT_API_KEY")
 
     // Set up callback to sync affiliate attributes to RevenueCat whenever they change
+    // Note: Use preventAffiliateTransfer in initialize() to block affiliate changes in the SDK
     InsertAffiliateSwift.setInsertAffiliateIdentifierChangeCallback { identifier, offerCode in
       guard let identifier = identifier else { return }
 
       // Ensure subscriber exists before setting attributes
       Purchases.shared.getCustomerInfo { customerInfo, error in
+        guard let customerInfo = customerInfo else { return }
+
+        // OPTIONAL: Prevent attribution for existing subscribers
+        // Uncomment to ensure affiliates only earn from users they actually brought:
+        // if !customerInfo.entitlements.active.isEmpty { return } // User already subscribed, don't attribute
+
         // Set attributes for tracking and targeting
         var attributes: [String: String] = [
           "insert_affiliate": identifier,

--- a/Sources/InsertAffiliateSwift/InsertAffiliateSwift.swift
+++ b/Sources/InsertAffiliateSwift/InsertAffiliateSwift.swift
@@ -10,13 +10,15 @@ actor InsertAffiliateState {
     private var insertLinksEnabled = false
     private var insertLinksClipboardEnabled = false
     private var affiliateAttributionActiveTime: TimeInterval?
+    private var preventAffiliateTransfer = false
 
     func initialize(
         companyCode: String,
         verboseLogging: Bool = false, // When set to true, the SDK will print verbose logs to the console to help with debugging. This should be set to false in production.
         insertLinksEnabled: Bool = false, // When set to true, the SDK will activate deep links and universal links. If you are using an external provider for deep links, set this to false.
         insertLinksClipboardEnabled: Bool = false, // When set to true, the SDK use the clipboard to improve the effectiveness of deep links. This will trigger a prompt for the user to allow the app to paste from the clipboard upon init of our SDK.
-        affiliateAttributionActiveTime: TimeInterval? = nil // Optional time interval (in seconds) for how long attribution remains active after affiliate link click
+        affiliateAttributionActiveTime: TimeInterval? = nil, // Optional time interval (in seconds) for how long attribution remains active after affiliate link click
+        preventAffiliateTransfer: Bool = false // When true, prevents new affiliate links from overwriting existing attribution
     ) throws {
         guard !isInitialized else {
             throw NSError(domain: "InsertAffiliateSwift", code: 1, userInfo: [NSLocalizedDescriptionKey: "SDK is already initialized."])
@@ -27,6 +29,7 @@ actor InsertAffiliateState {
         self.insertLinksEnabled = insertLinksEnabled
         self.insertLinksClipboardEnabled = insertLinksClipboardEnabled
         self.affiliateAttributionActiveTime = affiliateAttributionActiveTime
+        self.preventAffiliateTransfer = preventAffiliateTransfer
         isInitialized = true
     }
 
@@ -50,6 +53,10 @@ actor InsertAffiliateState {
         return affiliateAttributionActiveTime
     }
 
+    func getPreventAffiliateTransfer() -> Bool {
+        return preventAffiliateTransfer
+    }
+
     func reset() {
         companyCode = nil
         isInitialized = false
@@ -57,12 +64,13 @@ actor InsertAffiliateState {
         insertLinksEnabled = false
         insertLinksClipboardEnabled = false
         affiliateAttributionActiveTime = nil
+        preventAffiliateTransfer = false
         print("[Insert Affiliate] SDK has been reset.")
     }
 }
 
 public struct InsertAffiliateSwift {
-    public typealias InsertAffiliateIdentifierChangeCallback = (String?) -> Void
+    public typealias InsertAffiliateIdentifierChangeCallback = (String?, String?) -> Void  // (identifier, offerCode)
     private static let callbackQueue = DispatchQueue(label: "com.insertaffiliate.callback", attributes: .concurrent)
     nonisolated(unsafe) private static var _insertAffiliateIdentifierChangeCallback: InsertAffiliateIdentifierChangeCallback?
     
@@ -86,6 +94,7 @@ public struct InsertAffiliateSwift {
     private static let insertLinksEnabledKey = "InsertLinks_InsertLinksEnabled"
     private static let insertLinksClipboardEnabledKey = "InsertLinks_InsertLinksClipboardEnabled"
     private static let affiliateAttributionActiveTimeKey = "InsertAffiliate_AttributionActiveTime"
+    private static let preventAffiliateTransferKey = "InsertAffiliate_PreventAffiliateTransfer"
     private static let sdkInitReportedKey = "InsertAffiliate_SdkInitReported"
     private static let reportedAffiliateAssociationsKey = "InsertAffiliate_ReportedAssociations"
 
@@ -120,6 +129,11 @@ public struct InsertAffiliateSwift {
                 UserDefaults.standard.removeObject(forKey: affiliateAttributionActiveTimeKey)
             }
         }
+    }
+
+    private static var preventAffiliateTransfer: Bool {
+        get { UserDefaults.standard.bool(forKey: preventAffiliateTransferKey) }
+        set { UserDefaults.standard.set(newValue, forKey: preventAffiliateTransferKey) }
     }
 
     /// Reports SDK initialization to the backend for onboarding verification.
@@ -241,11 +255,12 @@ public struct InsertAffiliateSwift {
     }
 
     public static func initialize(
-        companyCode: String, 
+        companyCode: String,
         verboseLogging: Bool = false,
         insertLinksEnabled: Bool = false,
         insertLinksClipboardEnabled: Bool = false,
-        affiliateAttributionActiveTime: TimeInterval? = nil
+        affiliateAttributionActiveTime: TimeInterval? = nil,
+        preventAffiliateTransfer: Bool = false
     ) {
         guard #available(iOS 13.0, *) else {
             print("[Insert Affiliate] This SDK requires iOS 13.0 or newer.")
@@ -256,6 +271,7 @@ public struct InsertAffiliateSwift {
         self.insertLinksEnabled = insertLinksEnabled
         self.insertLinksClipboardEnabled = insertLinksClipboardEnabled
         self.affiliateAttributionActiveTime = affiliateAttributionActiveTime
+        self.preventAffiliateTransfer = preventAffiliateTransfer
 
         // Report SDK initialization for onboarding verification (fire and forget)
         reportSdkInitIfNeeded(companyCode: companyCode, verboseLogging: verboseLogging)
@@ -263,11 +279,12 @@ public struct InsertAffiliateSwift {
         Task {
             do {
                 try await state.initialize(
-                    companyCode: companyCode, 
+                    companyCode: companyCode,
                     verboseLogging: verboseLogging,
                     insertLinksEnabled: insertLinksEnabled,
                     insertLinksClipboardEnabled: insertLinksClipboardEnabled,
-                    affiliateAttributionActiveTime: affiliateAttributionActiveTime
+                    affiliateAttributionActiveTime: affiliateAttributionActiveTime,
+                    preventAffiliateTransfer: preventAffiliateTransfer
                 )
                 let _ = getOrCreateUserAccountToken()
                 
@@ -490,6 +507,24 @@ public struct InsertAffiliateSwift {
             return
         }
 
+        // Prevent transfer of affiliate if enabled - keep original affiliate
+        Task {
+            let verboseLogging = await state.getVerboseLogging()
+            if verboseLogging {
+                print("[Insert Affiliate] preventAffiliateTransfer check: enabled=\(preventAffiliateTransfer), existingIdentifier=\(existingIdentifier ?? "nil"), newIdentifier=\(insertAffiliateIdentifier)")
+            }
+        }
+
+        if preventAffiliateTransfer && existingIdentifier != nil {
+            Task {
+                let verboseLogging = await state.getVerboseLogging()
+                if verboseLogging {
+                    print("[Insert Affiliate] Transfer blocked: existing affiliate \"\(existingIdentifier!)\" protected from being replaced by \"\(insertAffiliateIdentifier)\"")
+                }
+            }
+            return
+        }
+
         // Different affiliate identifier, store it and update the date
         UserDefaults.standard.set(insertAffiliateIdentifier, forKey: "insertAffiliateIdentifier")
 
@@ -511,18 +546,20 @@ public struct InsertAffiliateSwift {
             }
         }
 
-        // Notify callback of identifier change
-        insertAffiliateIdentifierChangeCallback?(insertAffiliateIdentifier)
-
-        // Automatically fetch and store offer code ONLY if it's a short code
+        // Automatically fetch and store offer code ONLY if it's a short code, then notify callback
         if isShortCode(referringLink) {
             Task {
                 await retrieveAndStoreOfferCode(affiliateLink: referringLink) { offerCode in
                     if let offerCode = offerCode {
                         print("[Insert Affiliate] Automatically retrieved and stored offer code: \(offerCode)")
                     }
+                    // Notify callback of identifier change with offer code
+                    insertAffiliateIdentifierChangeCallback?(insertAffiliateIdentifier, offerCode)
                 }
             }
+        } else {
+            // Notify callback of identifier change without offer code
+            insertAffiliateIdentifierChangeCallback?(insertAffiliateIdentifier, nil)
         }
 
         // Report this new affiliate association to the backend (fire and forget)
@@ -587,6 +624,33 @@ public struct InsertAffiliateSwift {
     /// If no timeout is configured, always returns true if affiliate exists
     public static func isAffiliateAttributionValid() -> Bool {
         return returnInsertAffiliateIdentifier() != nil
+    }
+
+    /// Returns the Unix timestamp (in milliseconds) when the affiliate attribution expires
+    /// Returns nil if no timeout is configured or no affiliate is stored
+    public static func getAffiliateExpiryTimestamp() -> Int64? {
+        // Check if attribution timeout is configured
+        guard let attributionTimeout = affiliateAttributionActiveTime else {
+            // No timeout configured
+            return nil
+        }
+
+        // Check if stored date exists
+        guard let storedDateString = UserDefaults.standard.string(forKey: "affiliateStoredDate") else {
+            // No stored date
+            return nil
+        }
+
+        // Parse stored date
+        let dateFormatter = ISO8601DateFormatter()
+        guard let storedDate = dateFormatter.date(from: storedDateString) else {
+            // Invalid date format
+            return nil
+        }
+
+        // Calculate expiry timestamp (stored date + timeout in seconds) in milliseconds
+        let expiryDate = storedDate.addingTimeInterval(attributionTimeout)
+        return Int64(expiryDate.timeIntervalSince1970 * 1000)
     }
     
     public static var OfferCode: String? {


### PR DESCRIPTION
Resolves three things:

1. RevenueCat affiliateAttributionActiveTime - this modified approach ensures that only new transactions are prevented from being logged after the timeout has expired whilst still allowing renewals to continue (to modify renewals length, use https://docs.insertaffiliate.com/renewal-attribution-window)

2. We've added a way for you to prevent one affiliate hijacking transactions from another by first checking if one was already set. This is optional, some users wish to reward the affiliate that got a user to go back to the app most recently - some want the first affiliate that got the initial transaction to continue receiving their earned rewards.

3. We've added a way in our documentation for you to prevent an affiliate taking renewals they did not earn (a subscription that occurred before the link was clicked). This is once again optional, we advise you pay affiliates the renewals if they encourage the user to return to the app if your goal is to get the affiliate to time to first pound as quickly as possible.

By allowing this, you may encourage bad actors to advertise to try and get your existing subscribers to click their links for a payment - from our experience, your users like your app and what you do if they're paying for it, and would very likely report this sort of action to you quite quickly, allowing you to remove that bad actor whilst still rewarding other affiliates.

2 and 3 from this list are business decisions - we can only advise here from our experience, but we will leave you with the flexibility to make the decision which suits your app best.