### PR TITLE
Add Universal Links support for iOS

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -604,6 +604,85 @@ xcrun simctl openurl booted "YOUR_IOS_URL_SCHEME://TEST_SHORT_CODE"
 
 ✅ **Insert Links setup complete!** Skip to [Verify Your Integration](#-verify-your-integration)
 
+#### Universal Links
+
+Universal Links provide a better user experience than custom URL schemes. When a user taps an Insert Link and already has your app installed, iOS opens the app directly — without loading the browser and without showing a "Safari cannot open the page" error. If the app is not installed, the link opens normally in Safari with no error.
+
+**Prerequisites:**
+- Complete the [Universal Links setup steps](https://docs.insertaffiliate.com/insert-links#23-universal-links-optional-recommended) in the Insert Affiliate documentation — this includes entering your **Apple Team ID** and **iOS Bundle Identifier** in the dashboard settings
+
+**Step 1: Add Associated Domains in Xcode**
+
+Go to your app target → **Signing & Capabilities** → **+ Capability** → **Associated Domains**.
+
+Add the following:
+
+```
+applinks:insertaffiliate.link
+```
+
+If you have a [custom domain](https://docs.insertaffiliate.com/custom-domains) set up (e.g. `links.yourcompany.com`), also add:
+
+```
+applinks:links.yourcompany.com
+```
+
+**Step 2: Handle Universal Links in your app**
+
+The `handleInsertLinks` method accepts both custom URL scheme URLs and Universal Link URLs.
+
+**UIKit (AppDelegate)**
+
+Make sure your `AppDelegate` includes the `continue userActivity` method:
+
+```swift
+func application(_ application: UIApplication,
+                 continue userActivity: NSUserActivity,
+                 restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+    if let url = userActivity.webpageURL {
+        InsertAffiliateSwift.handleInsertLinks(url)
+    }
+    return true
+}
+```
+
+**SwiftUI**
+
+In SwiftUI apps, Universal Links are delivered via the **scene lifecycle**, not the AppDelegate. `.onOpenURL` only handles custom URL schemes — you must also add `.onContinueUserActivity` for Universal Links:
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .onOpenURL { url in
+                    // Handles custom URL scheme (ia-companycode://)
+                    InsertAffiliateSwift.handleInsertLinks(url)
+                }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
+                    // Handles Universal Links (https://insertaffiliate.link/...)
+                    if let url = userActivity.webpageURL {
+                        InsertAffiliateSwift.handleInsertLinks(url)
+                    }
+                }
+        }
+    }
+}
+```
+
+> **Note:** If you only add `.onOpenURL`, Universal Links will open the app but `handleInsertLinks` will never be called and attribution will not be tracked.
+
+**Testing Universal Links:**
+
+```bash
+# Test with your Insert Link URL
+xcrun simctl openurl booted "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
+
+# Or with your custom domain
+xcrun simctl openurl booted "https://links.yourcompany.com/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
+```
+
 </details>
 
 <details>

--- a/Sources/InsertAffiliateSwift/InsertAffiliateSwift.swift
+++ b/Sources/InsertAffiliateSwift/InsertAffiliateSwift.swift
@@ -879,12 +879,19 @@ public struct InsertAffiliateSwift {
         if let scheme = url.scheme, scheme.starts(with: "ia-") {
             return handleCustomURLScheme(url)
         }
-        
-        // Handle universal links (https://insertaffiliate.link/V1/companycode/shortcode)
+
+        // Handle universal links from insertaffiliate.link (legacy format: /V1/companycode/shortcode)
         if url.scheme == "https" && url.host?.contains("insertaffiliate.link") == true {
             return handleUniversalLink(url)
         }
-        
+
+        // Handle universal links from any domain (custom domains, e.g. share.getavo.co/companyId/shortCode)
+        // iOS only delivers universal links if the domain is in the app's Associated Domains entitlement,
+        // so we don't need to validate the domain — just extract the short code from the path.
+        if url.scheme == "https" {
+            return handleCustomDomainUniversalLink(url)
+        }
+
         return false
     }
     
@@ -918,19 +925,26 @@ public struct InsertAffiliateSwift {
         return true
     }
 
-    /// Handle universal links like https://insertaffiliate.link/V1/companycode/shortcode
+    /// Handle universal links like https://insertaffiliate.link/companycode/shortcode
+    /// Also supports legacy format: https://insertaffiliate.link/V1/companycode/shortcode
     private static func handleUniversalLink(_ url: URL) -> Bool {
-        let pathComponents = url.pathComponents
-        
-        // Expected format: /V1/companycode/shortcode
-        guard pathComponents.count >= 4,
-              pathComponents[1] == "V1" else {
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+
+        let companyCode: String
+        let shortCode: String
+
+        if pathComponents.count >= 3 && pathComponents[0] == "V1" {
+            // Legacy format: /V1/companycode/shortcode
+            companyCode = pathComponents[1]
+            shortCode = pathComponents[2]
+        } else if pathComponents.count >= 2 {
+            // Current format: /companycode/shortcode
+            companyCode = pathComponents[0]
+            shortCode = pathComponents[1]
+        } else {
             print("[Insert Affiliate] Invalid universal link format: \(url.absoluteString)")
             return false
         }
-        
-        let companyCode = pathComponents[2]
-        let shortCode = pathComponents[3]
         
         print("[Insert Affiliate] Universal link detected - Company: \(companyCode), Short code: \(shortCode)")
         
@@ -945,6 +959,36 @@ public struct InsertAffiliateSwift {
         
         // Process the affiliate attribution
         processAffiliateAttribution(shortCode: shortCode, companyCode: companyCode, source: .universalLink)
+
+        return true
+    }
+
+    /// Handle universal links from custom domains (e.g. https://share.getavo.co/companyId/shortCode)
+    /// Since iOS only delivers universal links for domains in the app's Associated Domains entitlement,
+    /// we trust that the URL is valid and just extract the short code from the path.
+    private static func handleCustomDomainUniversalLink(_ url: URL) -> Bool {
+        let pathComponents = url.pathComponents.filter { $0 != "/" }
+
+        // Expected format: /companyId/shortCode (2 path components)
+        guard pathComponents.count >= 2 else {
+            return false
+        }
+
+        let urlCompanyCode = pathComponents[0]
+        let shortCode = pathComponents[1]
+
+        // Validate company code matches the initialized one
+        Task {
+            if let initializedCompanyCode = await state.getCompanyCode() {
+                if urlCompanyCode.lowercased() != initializedCompanyCode.lowercased() {
+                    print("[Insert Affiliate] Custom domain universal link company code (\(urlCompanyCode)) doesn't match initialized company code (\(initializedCompanyCode)), ignoring")
+                    return
+                }
+
+                print("[Insert Affiliate] Custom domain universal link detected - Short code: \(shortCode)")
+                processAffiliateAttribution(shortCode: shortCode, companyCode: initializedCompanyCode, source: .universalLink)
+            }
+        }
 
         return true
     }


### PR DESCRIPTION
## Summary
- Fix URL parsing to support `/companyCode/shortCode` format (not just legacy `/V1/` format)
- Add custom domain Universal Links support
- Update README with SwiftUI `onContinueUserActivity` guidance and Associated Domains setup

## Test plan
- [x] Tested on iPhone 14 Pro with `insertaffiliate.link` domain
- [x] Tested with custom domain `test-custom.insertaffiliate.com`
- [x] Both default and custom domain links open app directly